### PR TITLE
Add client-operation-logging for cockpit-machines

### DIFF
--- a/packaging/cockpit-machines.spec.in
+++ b/packaging/cockpit-machines.spec.in
@@ -82,11 +82,29 @@ If "virt-install" is installed, you can also create new virtual machines.
 %make_install PREFIX=/usr
 appstream-util validate-relax --nonet %{buildroot}/%{_datadir}/metainfo/*
 
+install -Dm644 %{_sourcedir}/src/systemd/cockpit-machines-logging.service %{buildroot}%{_unitdir}/cockpit-machines-logging.service
+install -Dm644 %{_sourcedir}/src/config/cockpit-machines-logging.conf %{buildroot}%{_sysconfdir}/libvirt/cockpit-machines-logging.conf
+install -Dm644 %{_sourcedir}/src/config/cockpit-machines-logging %{buildroot}%{_sysconfdir}/logrotate.d/cockpit-machines-logging
+install -Dm755 src/bin/cockpit-machines-logging %{buildroot}%{_bindir}/cockpit-machines-logging
+
+%post
+%systemd_post cockpit-machines-logging.service
+
+%preun
+%systemd_preun cockpit-machines-logging.service
+
 %files
 %doc README.md
 %license LICENSE dist/index.js.LEGAL.txt dist/index.css.LEGAL.txt
 %{_datadir}/cockpit/*
 %{_datadir}/metainfo/*
+
+%{_unitdir}/cockpit-machines-logging.service
+
+%{_sysconfdir}/libvirt/cockpit-machines-logging.conf
+%{_sysconfdir}/logrotate.d/cockpit-machines-logging
+
+%attr(0755, root, root) %{_bindir}/cockpit-machines-logging
 
 # The changelog is automatically generated and merged
 %changelog

--- a/src/bin/cockpit-machines-logging
+++ b/src/bin/cockpit-machines-logging
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+LOGFILE=`grep LOG-FILE /etc/libvirt/cockpit-machines-logging.conf | cut -d " " -f 3`
+
+busctl monitor org.libvirt.Domain > $LOGFILE

--- a/src/config/cockpit-machines-logging
+++ b/src/config/cockpit-machines-logging
@@ -1,0 +1,9 @@
+/var/log/libvirt/cockpit-machines.log {
+        weekly
+        missingok
+        rotate 4
+        compress
+        delaycompress
+        copytruncate
+        minsize 100k
+}

--- a/src/config/cockpit-machines-logging.conf
+++ b/src/config/cockpit-machines-logging.conf
@@ -1,0 +1,3 @@
+# Describes the name and path of the log file output 
+# by cockpit-machines-logging.service.
+LOG-FILE = /var/log/libvirt/cockpit-machines.log

--- a/src/systemd/cockpit-machines-logging.service
+++ b/src/systemd/cockpit-machines-logging.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Cockpit machines logging
+Documentation=man:cockpit-machines
+Requires=cockpit.service
+After=cockpit.service
+
+[Service]
+ExecStart=/usr/bin/cockpit-machines-logging
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Add the ability to log operations performed in cockpit-machines.
With this addition, if any error occurs on the cockpit-machines side, 
detailed information about the error can be obtained without having to 
reproduce it.